### PR TITLE
frontend build now can be served through the backend server

### DIFF
--- a/BackEnd/_env.js
+++ b/BackEnd/_env.js
@@ -8,6 +8,7 @@ module.exports = {
     DBUserName: process.env.DB_USER,
     DBPass: process.env.DB_PASS,
     DBName: process.env.DB_NAME,
+    WebServerPort: process.env.WEBSERVER_PORT,
 
     getGoogleBooksInfoAPIURL: function(ISBN) {
         return `https://books.google.com/books?jscmd=viewapi&callback=info&bibkeys=ISBN${ISBN}`;

--- a/BackEnd/index.js
+++ b/BackEnd/index.js
@@ -1,11 +1,14 @@
 const express = require('express');
+const path = require('path');
 const delay = require('delay');
+
+const env = require('./_env');
 
 const testData = require('./data/testData.json');
 
 
 const app = express();
-const port = 4088;
+const port = env.WebServerPort;
 
 app.use(function (req, res, next) {
     res.header("Access-Control-Allow-Origin", "*"); // update to match the domain you will make the request from
@@ -14,15 +17,20 @@ app.use(function (req, res, next) {
 });
 
 
+app.use(express.static(path.join(__dirname, '..//FrontEnd/build-test')));
+
+
 const delayResponseSec = 2; //this is just to simulate network lagg
 
+app.get('/', function (req, res) {
+    res.sendFile(path.join(__dirname, '..//FrontEnd/build-test', 'index.html'));
+});
 
+app.get('/api', (req, res, next) => res.send('Hello Friend, welcome to the API!'));
 
-app.get('/', (req, res, next) => res.send('Hello Friend, welcome to the API!'));
+app.get('/api/simpleTest', (req, res, next) => res.json(testData));
 
-app.get('/simpleTest', (req, res, next) => res.json(testData));
-
-app.get('/delayedTest', (req, res, next) => {
+app.get('/api/delayedTest', (req, res, next) => {
     (async() => {
     await delay(delayResponseSec * 1000);  // Executes after 3 seconds later
         res.json(testData)

--- a/FrontEnd/_env.js
+++ b/FrontEnd/_env.js
@@ -1,9 +1,7 @@
-const path = require('path')
-
-require('dotenv').config({ path: path.resolve(__dirname, '../.env') })
-
 module.exports = {
-    //eg: DBURL: process.env.DB_URL
+
+    WebServerBaseURL: process.env.WEBSERVER_BASEURL,
+    WebServerPort: process.env.WEBSERVER_PORT,
 
     Vtest: "testZZZ"  // stuff can be injected here, if needed
 };

--- a/FrontEnd/src/index-routed.js
+++ b/FrontEnd/src/index-routed.js
@@ -13,7 +13,7 @@ import HomePage from './pages/homePage';
 import materializeCSS from '../../node_modules/materialize-css/dist/css/materialize.min.css';
 import mainCSS from './index.scss';
 
-const home = () => { return (<HomePage pageTitle={"CheckList Hub - Homepage"} />) }
+const home = () => { return (<HomePage pageTitle={"Project Patoune - Homepage"} />) }
 const notFound = () => { return (<NotFoundPage pageTitle={"404 page"} />) }
 
 const routing = (

--- a/FrontEnd/src/pages/homePage.js
+++ b/FrontEnd/src/pages/homePage.js
@@ -14,18 +14,23 @@ import mainCSS from '../index.scss';
 
 ///section objects + components
 
+import ApiHub from '../services/ApiHub';
 
 class homePage extends React.Component{
 
     constructor(props) {
         super(props);
         this.state = {
-            pageTitle: this.props.pageTitle ? this.props.pageTitle : "CheckList Hub - Homepage"
+            pageTitle: this.props.pageTitle ? this.props.pageTitle : "CheckList Hub - Homepage",
+            testBox : ""
         };
     }
 
     componentDidMount() {
         document.title = this.state.pageTitle;
+
+        ApiHub.getTest().then((res)=>{console.log(res)});
+
     }
 
     render(){

--- a/FrontEnd/src/services/ApiHub.js
+++ b/FrontEnd/src/services/ApiHub.js
@@ -1,18 +1,23 @@
+const env = require('../../_env');
 import apiHelper from './ApiHelper';
-import apiconfig from './apiconfig';
+
 
 class ApiHub {
 
+    static serverBase () {
+        return `${env.WebServerBaseURL}:${env.WebServerPort}/api`
+    };
+
     static getTest() {
-        return apiHelper.get(`${apiconfig.serverBaseURL}/testData`).then(resp => resp);//(response => response.data);
+        return apiHelper.get(`${this.serverBase()}/simpleTest`).then(resp => resp);//(response => response.data);
     }
 
     static getTemplateList(){
-        return apiHelper.get(`${apiconfig.serverBaseURL}/getTemplateList`).then(resp => resp);
+        return apiHelper.get(`${this.serverBase()}/getTemplateList`).then(resp => resp);
     }
 
     static getTemplate(params){
-        return apiHelper.get(`${apiconfig.serverBaseURL}/getTemplate?id=${params.id}`).then(resp => resp);
+        return apiHelper.get(`${this.serverBase()}/getTemplate?id=${params.id}`).then(resp => resp);
     }
 
     /*

--- a/FrontEnd/src/services/apiconfig.js
+++ b/FrontEnd/src/services/apiconfig.js
@@ -1,5 +1,0 @@
-const apiconfig = {
-    serverBaseURL: "http://localhost:3008"
-}
-
-export default apiconfig;

--- a/FrontEnd/webpack.common.js
+++ b/FrontEnd/webpack.common.js
@@ -1,6 +1,7 @@
 const path = require("path");
 const { CleanWebpackPlugin } = require('clean-webpack-plugin'); //this is used to focefully delete the output folder before every build
 const MiniCssExtractPlugin = require("mini-css-extract-plugin"); //this is to create indiidual css files
+const Dotenv = require('dotenv-webpack');
 
 module.exports = {
     entry: {
@@ -64,6 +65,14 @@ module.exports = {
     },
     plugins: [
         new CleanWebpackPlugin(), //delete output folder before build
-        new MiniCssExtractPlugin({ filename: '[name].[contentHash].css' }) //create actual css files
+        new MiniCssExtractPlugin({ filename: '[name].[contentHash].css' }), //create actual css files
+        new Dotenv({
+            path: '../.env', // load this now instead of the ones in '.env'
+            safe: false, // load '.env.example' to verify the '.env' variables are all set. Can also be a string to a different file.
+            allowEmptyValues: true, // allow empty variables (e.g. `FOO=`) (treat it as empty string, rather than missing)
+            systemvars: true, // load all the predefined 'process.env' variables which will trump anything local per dotenv specs.
+            silent: false, // hide any errors
+            defaults: false // load '.env.defaults' as the default values if empty.
+        })
     ]
 }

--- a/FrontEnd/webpack.prod.js
+++ b/FrontEnd/webpack.prod.js
@@ -5,6 +5,8 @@ const OptimizeCssAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 var HtmlWebpackPlugin = require("html-webpack-plugin");
 
+///fixme thes build config is not working for some reason...
+
 module.exports = merge(common, {
     mode: "production",
     output: {

--- a/HowToRunMe.md
+++ b/HowToRunMe.md
@@ -1,0 +1,13 @@
+## to run frontend through the backend
+
+* -> webpack-watch (devserver WONT WORK) / slower
+* -> backend-server
+
+access it through the `WEBSERVER_BASEURL` and `WEBSERVER_PORT`
+page also needs manual refreshing
+
+
+## to run frontend and backend independently _(this will only work till GoogleSignIn)_
+
+* -> webpack-devserver
+* -> backend-server

--- a/package-lock.json
+++ b/package-lock.json
@@ -6478,7 +6478,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-1.1.1.tgz",
       "integrity": "sha512-6fPRo9o/3MxKvmRZBD3oNFdxODdhJtIy1zcJeUSCs6HCy4tarUpd+G67UTU9tF6OWXeSPqsm4fPAB+2eY9Rt9Q==",
-      "dev": true,
       "requires": {
         "dotenv": "^6.2.0"
       },
@@ -6486,8 +6485,7 @@
         "dotenv": {
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
-          "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
-          "dev": true
+          "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
         }
       }
     },
@@ -6498,10 +6496,9 @@
       "dev": true
     },
     "dotenv-webpack": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.7.0.tgz",
-      "integrity": "sha512-wwNtOBW/6gLQSkb8p43y0Wts970A3xtNiG/mpwj9MLUhtPCQG6i+/DSXXoNN7fbPCU/vQ7JjwGmgOeGZSSZnsw==",
-      "dev": true,
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-1.8.0.tgz",
+      "integrity": "sha512-o8pq6NLBehtrqA8Jv8jFQNtG9nhRtVqmoD4yWbgUyoU3+9WBlPe+c2EAiaJok9RB28QvrWvdWLZGeTT5aATDMg==",
       "requires": {
         "dotenv-defaults": "^1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "webpack-devserver": "cd FrontEnd && webpack-dev-server --config webpack.dev.js --inline --colors",
     "webpack-watch": "cd FrontEnd && webpack --watch --config webpack.dev.js --colors",
     "storybook": "start-storybook",
-    "BackEnd-server (nodemon)": "cd BackEnd && nodemon index.js"
+    "backEnd-server": "cd BackEnd && nodemon index.js"
   },
   "repository": {
     "type": "git",
@@ -43,6 +43,7 @@
     "crypto-random-string": "^3.2.0",
     "delay": "^4.3.0",
     "dotenv": "^8.2.0",
+    "dotenv-webpack": "^1.8.0",
     "express": "^4.17.1",
     "html-to-json": "^0.6.0",
     "materialize-css": "^1.0.0",


### PR DESCRIPTION
it's kind of an important bit, so thought it worth its own PR
(also a precursor for the GoogleSing-in feature)

once this is merged;
- `npm install`
- add the following to your local `.env` file;
```
WEBSERVER_BASEURL = "http://localhost"
WEBSERVER_PORT = 4088
```